### PR TITLE
Add links to Greg Wooladge's and Bash Hakers wikis

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [zshmarks](https://github.com/jocelynmallon/zshmarks) - A port of Bashmarks (simple bookmarking plugin by Todd Werth) for oh-my-zsh
 
 # Guides
+* [Greg Wooledge's (aka "greycat") wiki](http://mywiki.wooledge.org).
+  Specifically [Bash Guide](http://mywiki.wooledge.org/BashGuide), [Bash FAQ](http://mywiki.wooledge.org/BashFAQ) and [Bash Pitfalls](http://mywiki.wooledge.org/BashPitfalls)
+* [Bash Hackers Wiki] (http://wiki.bash-hackers.org/)
 * [The Linux Documentation Project: Bash Programming - Intro/How-to](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO.html#toc)
 * [The Linux Documentation Project: Advanced Bash Scripting Guide](http://www.tldp.org/LDP/abs/html/)
 * [WikiBooks: Bash Shell Scripting](http://en.wikibooks.org/wiki/Bash_Shell_Scripting)


### PR DESCRIPTION
Greg has assembled one of the greatest guides and FAQs about Bash
and shell scripting in general.  It's the must read material for
anybody who does any significant amount of shell scripting.

Bash Hackers Wiki contains loads of verified, up-to-date
information related to Bash and shell scripting.
