### PR TITLE
Adding dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [bashful](https://github.com/jmcantrell/bashful) - A collection of libraries to simplify writing bash scripts
 * [bats](https://github.com/sstephenson/bats) - Bash Automated Testing System
 * [composure](https://github.com/erichs/composure) - Compose, document, version and organize your shell functions
+* [dispatch](https://github.com/Mosai/workshop/blob/master/doc/dispatch.md) - A command line argument parser in 50 lines of portable shell script.
 * [sub](https://github.com/basecamp/sub) - a delicious way to organize programs
 
 ## Multimedia


### PR DESCRIPTION
dispatch is a very portable and lightweight command line argument parser. 

It has been tested on several versions of bash, dash, ksh, zsh, mksh, pdksh, yash and busybox and requires no dependencies. It has less than 50 (commented) lines of code.
