### PR TITLE
Edit slap editor description: it needs Node.js to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [jrnl](https://github.com/maebert/jrnl) - A simple command line journal application that stores your journal in a plain text file
 * [semver_bash](https://github.com/cloudflare/semver_bash) - Semantic Versioning in Bash
 * [shellcheck](https://github.com/koalaman/shellcheck) - Static analysis tool for shell scripts
-* [slap](https://github.com/slap-editor/slap) - Sublime-like terminal-based text editor
+* [slap](https://github.com/slap-editor/slap) - Sublime-like terminal-based text editor that runs on Node.js
 * [spark](https://github.com/holman/spark) - ▁▂▃▅▂▇ in your shell
 * [spot](https://github.com/guille/spot) - Tiny file search utility
 * [wemux](https://github.com/zolrath/wemux) - Multi-User Tmux Made Easy


### PR DESCRIPTION
It is important to highlight that [slap](https://github.com/slap-editor/slap), the Sublime-like terminal editor, is written in Javascript and needs Node.js interpreter in order to be run. 

It is valuable to know right away as it means that if you want to install it on a remote machine,  you will need to install Node.js as well.
