### PR TITLE
add facy: command line power tool for facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [ansiweather](https://github.com/fcambus/ansiweather) - Weather in your terminal, with ANSI colors and Unicode symbols
 * [bashblog](https://github.com/cfenollosa/bashblog) - A Bash script that handles blog posting
 * [choosealicense-cli](https://github.com/lord63/choosealicense-cli) - Bring http://choosealicense.com to your terminal
+* [facy](https://github.com/huydx/facy) - Command line power tool for facebook
 * [geeknote](https://github.com/VitaliyRodnenko/geeknote) - Command line evernote client
 * [isitup](https://github.com/lord63/isitup) - Check whether a website is up or down
 * [jrnl](https://github.com/maebert/jrnl) - A simple command line journal application that stores your journal in a plain text file


### PR DESCRIPTION
Hi @alebcay , i've added the command line tool i wrote before, which used to access facebook inside your terminal. Please take a look, and feedbacks are welcome.
Thank you.