### PR TITLE
Remove fish and zsh items and link to corresponding awesome list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Shell [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Shell [![Awesome][awesome-badge]][awesome-link]
 
 A curated list of awesome command-line frameworks, toolkits, guides and gizmos. Inspired by awesome-php. This awesome collection is also available on [Unix-Shell.ZEEF.com](https://unix-shell.zeef.com/caleb.xu).
 - [Awesome Bash](#awesome-bash)
@@ -12,10 +12,13 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 	- [Games](#games)
 	- [Shell Package Management](#shell-package-management)
 	- [Shell Script Development](#shell-script-development)
-	- [Zsh](#zsh)
-	- [Fish](#fish)
 - [Guides](#guides)
+- [**Awesome Zsh**][awesome-zsh]&nbsp; [![Awesome][awesome-badge]][awesome-zsh]
+- [**Awesome Fish**][awesome-fish] [![Awesome][awesome-badge]][awesome-fish]
 - [Other Awesome Lists](#other-awesome-lists)
+
+
+# Awesome Bash
 
 
 ## Command-Line Productivity
@@ -183,10 +186,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [bpkg](http://www.bpkg.io/) - JavaScript has npm, Ruby has Gems, Python has pip and now Shell has bpkg
 * [dotfiler](https://github.com/svetlyak40wt/dotfiler) – Shell agnostic git based dotfiles package manager, written in Python.
 * [fresh](https://github.com/freshshell/fresh) - Keep your dotfiles fresh
-* [Fisherman](https://github.com/fisherman/fisherman) - Fish Shell Plugin Manager 
 * [homeshick](https://github.com/andsens/homeshick) - Git dotfile synchronizer written in Bash
-* [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) - Framework for managing your Fish shell configuration inspired by Oh My Zsh
-* [Wahoo](https://github.com/bucaran/wahoo) - All-purpose framework and decentralized package manager for the fishshell.
 * [vcsh](https://github.com/RichiH/vcsh) - Config manager based on Git
 
 ## Shell Script Development
@@ -198,7 +198,6 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [bashful](https://github.com/unterzicht/bashful) - A collection of libraries to simplify writing Bash scripts
 * [bashmanager](https://github.com/lingtalfi/bashmanager) - mini bash framework for creating command line tools
 * [bats](https://github.com/sstephenson/bats) - Bash Automated Testing System
-* [Fishtape](https://github.com/fisherman/fishtape) - TAP producer and test harness for fish
 * [composure](https://github.com/erichs/composure) - Compose, document, version and organize your shell functions
 * [dispatch](https://github.com/Mosai/workshop/blob/master/doc/dispatch.md) - A command line argument parser in 50 lines of portable shell script.
 * [mo](https://github.com/tests-always-included/mo) - Mustache templates in pure bash
@@ -210,37 +209,6 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [ts](https://github.com/thinkerbot/ts) - A shell test script
 * [shunit2](https://github.com/kward/shunit2) - A unit test framework for Bash scripts with a flavour of JUnit/PyUnit.
 
-## Zsh
-
-*Tools and customizations specifically for Zsh.*
-
-* [antigen-hs](https://github.com/Tarrasch/antigen-hs) - A replacement for antigen optimized for a low overhead when starting up the shell.
-* [antibody](https://github.com/caarlos0/antibody) - A faster and simpler replacement for antigen written in Go.
-* [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) - A list of Zsh plugins usable with antigen, dotzsh, oh-my-zsh & prezto.
-* [antigen](https://github.com/zsh-users/antigen) - A plugin manager for Zsh, inspired by oh-my-zsh and vundle
-* [dotzsh](https://github.com/dotphiles/dotzsh) - dotzsh strives to be platform and version independent, some functionality may be lost when running under older versions of Zsh, but it should degrade cleanly and allow you to use the same setup on multiple machines of differing OS's without problems.
-* [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) - A community-driven framework for managing your Zsh configuration
-* [pretty-time-zsh](https://github.com/sindresorhus/pretty-time-zsh) - Convert seconds to a human readable string: `165392` → `1d 21h 56m 32s`
-* [powerline-zsh](https://github.com/carlcarl/powerline-zsh) - Powerline for Zsh
-* [prezto](https://github.com/sorin-ionescu/prezto) - The configuration framework for Zsh
-* [pure](https://github.com/sindresorhus/pure) - Pretty, minimal and fast Zsh prompt
-* [zgen](https://github.com/tarjoilija/zgen) - A lightweight plugin manager for Zsh inspired by antigen, but optimized for speed when starting a new shell. Can load oh-my-zsh compatible plugins and themes.
-* [zplug](https://github.com/b4b4r07/zplug) - :hibiscus: A next-generation plugin manager for zsh
-* [zsh-autosuggestions](https://github.com/tarruda/zsh-autosuggestions) - Fish-like autosuggestions for Zsh
-* [zsh-dwim](https://github.com/oknowton/zsh-dwim) - Zsh do what I mean.
-* [zsh-git-prompt](https://github.com/olivierverdier/zsh-git-prompt) - Informative Git prompt for Zsh
-* [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - An implementation of the Fish shell's history search feature for Zsh.
-* [zshmarks](https://github.com/jocelynmallon/zshmarks) - A port of Bashmarks (simple bookmarking plugin by Todd Werth) for oh-my-zsh
-* [zsh-notify](https://github.com/marzocchi/zsh-notify) - Desktop notifications for long running commands in Zsh
-* [zsh-prompt-powerline](https://github.com/Valodim/zsh-prompt-powerline) - A Zsh prompt based on the powerline font from the popular vim plugin
-* [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - Fish shell like syntax highlighting for Zsh
-
-
-## Fish
-
-*Tools and customizations specifically for Fish.*
-
-* [fish-tmpdir](https://github.com/eush77/fish-tmpdir) - Fresh, one-time temporary directories for Fish.
 
 # Guides
 
@@ -258,3 +226,8 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 # Other Awesome Lists
 
 Other amazingly awesome lists can be found in [awesome-awesome](https://github.com/emijrp/awesome-awesome) and [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness).
+
+[awesome-zsh]: https://github.com/unixorn/awesome-zsh-plugins
+[awesome-fish]: https://github.com/bucaran/awesome-fish
+[awesome-link]: https://github.com/sindresorhus/awesome
+[awesome-badge]: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 
 * [adb-export](https://github.com/sromku/adb-export) - Export Android content providers to CSV format
 * [Android-Kitchen](https://github.com/dsixda/Android-Kitchen) - A text-based kitchen for Android ROM customization. Uses shell scripts and works with Cygwin/OS X/Linux
-* [Beets](https://github.com/sampsyo/beets) - Music library manager and MusicBrainz tagger
+* [Beets](https://github.com/beetbox/beets) - Music library manager and MusicBrainz tagger
 * [cmus](https://github.com/cmus/cmus) - Cross-platform cli audio player.
 * [image-scraper](https://github.com/sananth12/ImageScraper) - A cool command line image scraper with a lot of features.
 * [jq](https://github.com/stedolan/jq) - Sed for json data. You can use it to slice and filter and map and transform structured data

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 
 * [ansi](https://github.com/fidian/ansi) - ANSI escape codes in pure bash - change text color, position the cursor, much more
 * [assert.sh](https://github.com/lehmannro/assert.sh) - Bash unit testing framework
-* [bashful](https://github.com/unterzicht/bashful) - A collection of libraries to simplify writing Bash scripts
+* [bashful](https://github.com/jmcantrell/bashful) - A collection of libraries to simplify writing Bash scripts
 * [bashmanager](https://github.com/lingtalfi/bashmanager) - mini bash framework for creating command line tools
 * [bats](https://github.com/sstephenson/bats) - Bash Automated Testing System
 * [composure](https://github.com/erichs/composure) - Compose, document, version and organize your shell functions

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -1,4 +1,4 @@
-﻿# Awesome Shell [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Shell [![Awesome][awesome-badge]][awesome-link]
 
 这是一份非常棒的命令行框架、工具包、指南、以及小玩意儿组织清单。由 awesome-php 获得灵感。该 awesome 收集在 [Unix-Shell.ZEEF.com](https://unix-shell.zeef.com/caleb.xu) 上也可用。
 - [Awesome Bash](#awesome-bash)
@@ -12,8 +12,8 @@
     - [游戏](#游戏)
     - [Shell 包管理](#shell-包管理)
     - [Shell 脚本开发](#shell-脚本开发)
-    - [Zsh](#zsh)
-    - [Fish](#fish)
+- [**Awesome Zsh**][awesome-zsh]&nbsp; [![Awesome][awesome-badge]][awesome-zsh]
+- [**Awesome Fish**][awesome-fish] [![Awesome][awesome-badge]][awesome-fish]
 - [指南](#指南)
 - [其它 Awesome 清单](#其它-awesome-清单)
 
@@ -138,7 +138,7 @@
 
 * [adb-export](https://github.com/sromku/adb-export) - 导出 Android 内容提供商为 CSV 格式
 * [Android-Kitchen](https://github.com/dsixda/Android-Kitchen) - 基于文本的 Android ROM 定制 kitchen，使用 shell 脚本并支持 Cygwin/OS X/Linux
-* [Beets](https://github.com/sampsyo/beets) - 音乐库管理器及 MusicBrainz 标签工具
+* [Beets](https://github.com/beetbox/beets) - 音乐库管理器及 MusicBrainz 标签工具
 * [cmus](https://github.com/cmus/cmus) - 跨平台的命令行音乐播放器
 * [image-scraper](https://github.com/sananth12/ImageScraper) - 包含诸多特性的酷命令行图像 scraper
 * [jq](https://github.com/stedolan/jq) - 针对 json 数据的 Sed，你可以使用它分片、过滤、映射及变换结构化数据
@@ -186,10 +186,7 @@
 * [bpkg](http://www.bpkg.io/) - JavaScript 有 npm、Ruby 有 Gems、Python 有 pip，现在 Shell 有 bpkg
 * [dotfiler](https://github.com/svetlyak40wt/dotfiler) – 使用 Python 编写的基于 Git 的 Shell dotfiles 管理器
 * [fresh](https://github.com/freshshell/fresh) - 使你的 dotfiles 保持更新
-* [Fisherman](https://github.com/fisherman/fisherman) - Fish Shell 插件管理器
 * [homeshick](https://github.com/andsens/homeshick) - 使用 Bash 编写的 Git dotfile 同步器
-* [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) - 用于管理 Fish shell 配置的框架，由 Oh My Zsh 获得灵感
-* [Wahoo](https://github.com/bucaran/wahoo) - 适用于 Fish shell 的全功能框架及去中心化包管理器
 * [vcsh](https://github.com/RichiH/vcsh) - 基于 Git 的配置管理器
 
 ## Shell 脚本开发
@@ -203,7 +200,6 @@
 * [bats](https://github.com/sstephenson/bats) - Bash 自动化测试系统
 * [composure](https://github.com/erichs/composure) - 撰写、文档、版本、及组织你的 shell 函数
 * [dispatch](https://github.com/Mosai/workshop/blob/master/doc/dispatch.md) - 使用 50 行可移植 shell 脚本写成的命令行参数解析器
-* [Fishtape](https://github.com/fisherman/fishtape) - 适用于 fish 的 TAP 生产者及测试工具
 * [mo](https://github.com/tests-always-included/mo) - 使用纯 Bash 实现的 Mustache 模板
 * [rerun](https://github.com/rerun/rerun) - 用来管理保留脚本的模块化 shell 自动化框架
 * [semver_bash](https://github.com/cloudflare/semver_bash) - 使用 Bash 实现的语义化版本
@@ -212,38 +208,6 @@
 * [sub](https://github.com/basecamp/sub) - 以美味之道来管理程序
 * [ts](https://github.com/thinkerbot/ts) - shell 测试脚本
 * [shunit2](https://github.com/kward/shunit2) - 适用于 Bash 脚本的单元测试框架（具有 JUnit/PyUnit 风味）
-
-## Zsh
-
-*特别针对 Zsh 的工具及定制。*
-
-* [antigen-hs](https://github.com/Tarrasch/antigen-hs) - 针对启动 shell 时低开销进行优化的 antigen 替代品
-* [antibody](https://github.com/caarlos0/antibody) - 使用 Go 编写的更快且更简单的 antigen 替代品
-* [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) - 可用于 antigen、dotzsh、oh-my-zsh 及 prezto 的 Zsh 插件列表
-* [antigen](https://github.com/zsh-users/antigen) - 适用于 Zsh 的插件管理器，由 oh-my-zsh 及 vundle 获得灵感
-* [dotzsh](https://github.com/dotphiles/dotzsh) - dotzsh 力争变成平台和版本独立，在 Zsh 旧版本下运行时可能缺少某些功能，但它让你在多个不同的系统上使用相同的设置而没问题
-* [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) - 管理 Zsh 配置的社区化框架
-* [pretty-time-zsh](https://github.com/sindresorhus/pretty-time-zsh) - 将秒转换为人类可读的字符串: `165392` → `1d 21h 56m 32s`
-* [powerline-zsh](https://github.com/carlcarl/powerline-zsh) - 适用于 Zsh 的 powerline
-* [prezto](https://github.com/sorin-ionescu/prezto) - 针对 Zsh 的配置框架
-* [pure](https://github.com/sindresorhus/pure) - 漂亮、极简、及快速的 Zsh 提示符
-* [zgen](https://github.com/tarjoilija/zgen) - 适用于 Zsh 的轻量级插件管理器，由 antigen 获得灵感，但为启动新的 shell 时优化了速度，可载入 oh-my-zsh 兼容的插件和主题
-* [zplug](https://github.com/b4b4r07/zplug) - :hibiscus: 针对 zsh 的下一代插件管理器
-* [zsh-autosuggestions](https://github.com/tarruda/zsh-autosuggestions) - 适用于 Zsh 的类 Fish 自动建议
-* [zsh-dwim](https://github.com/oknowton/zsh-dwim) - Zsh 照我之意做
-* [zsh-git-prompt](https://github.com/olivierverdier/zsh-git-prompt) - 针对 Zsh 的 Git 信息提示符
-* [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - 针对 Zsh 实现的 Fish shell 的历史搜索功能
-* [zshmarks](https://github.com/jocelynmallon/zshmarks) - 针对 oh-my-zsh 的 Bashmarks 移植（由 Todd Werth 编写的简单书签插件）
-* [zsh-notify](https://github.com/marzocchi/zsh-notify) - 适用于在 Zsh 中长时运行命令的桌面通知
-* [zsh-prompt-powerline](https://github.com/Valodim/zsh-prompt-powerline) - 基于 powerline 字体（来自流行的 Vim 插件）的 Zsh 提示符
-* [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - 针对 Zsh 的类 Fish shell 语法着色功能
-
-
-## Fish
-
-*特别针对 Fish 的工具及定制。*
-
-* [fish-tmpdir](https://github.com/eush77/fish-tmpdir) - 适用于 Fish 的新的一次性临时目录
 
 
 # 指南
@@ -261,3 +225,9 @@
 # 其它 Awesome 清单
 
 其它很棒的 awesome 清单可在 [awesome-awesome](https://github.com/emijrp/awesome-awesome) 和 [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) 找到。
+
+
+[awesome-zsh]: https://github.com/unixorn/awesome-zsh-plugins
+[awesome-fish]: https://github.com/bucaran/awesome-fish
+[awesome-link]: https://github.com/sindresorhus/awesome
+[awesome-badge]: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -195,7 +195,7 @@
 
 * [ansi](https://github.com/fidian/ansi) - 使用纯 Bash 实现的 ANSI 转义码，包括更改文本颜色、定位光标等等
 * [assert.sh](https://github.com/lehmannro/assert.sh) - Bash 单元测试框架
-* [bashful](https://github.com/unterzicht/bashful) - 简化编写 Bash 脚本的库收集
+* [bashful](https://github.com/jmcantrell/bashful) - 简化编写 Bash 脚本的库收集
 * [bashmanager](https://github.com/lingtalfi/bashmanager) - 用来创建命令行工具的微型 Bash 框架
 * [bats](https://github.com/sstephenson/bats) - Bash 自动化测试系统
 * [composure](https://github.com/erichs/composure) - 撰写、文档、版本、及组织你的 shell 函数


### PR DESCRIPTION
+ Remove fish items and link to awesome-fish
+ Remove zsh items and link to awesome-zsh-plugins
> I manually checked whether each of the existing zsh items was or not in the awesome-zsh-plugins and every single one was there. :+1: 

+ Remove the same items from the Chinese version of the README. Did not add anything there.

@alebcay 
@sgoings
@xuxiaodong