### PR TITLE
Add taskwarrior, a todo list manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [pushbullet-bash](https://github.com/Red5d/pushbullet-bash) - Bash interface to the PushBullet API
 * [Reddit Terminal Viewer](https://github.com/michael-lazar/rtv) - Browse Reddit from your terminal
 * [SAWS](https://github.com/donnemartin/saws) - A Supercharged AWS CLI
+* [taskwarrior](https://taskwarrior.org/) - A command-line TODO list manager
 * [transfer.sh](https://transfer.sh/) — Quickly upload and share files from your shell
 * [vl](https://github.com/ellisonleao/vl) - URL link checker on text documents
 * [wego](https://github.com/schachmat/wego) - Weather app for the terminal

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -181,6 +181,7 @@
 * [pushbullet-bash](https://github.com/Red5d/pushbullet-bash) - PushBullet API 的 Bash 接口
 * [Reddit Terminal Viewer](https://github.com/michael-lazar/rtv) - 从终端浏览 Reddit
 * [SAWS](https://github.com/donnemartin/saws) - 超强的 AWS 命令行界面
+* [taskwarrior](https://taskwarrior.org/) - 一个命令行去做列表管理器
 * [transfer.sh](https://transfer.sh/) — 从 shell 快速上传并分享文件
 * [vl](https://github.com/ellisonleao/vl) - 针对文本文档的 URL 链接检查器
 * [wego](https://github.com/schachmat/wego) - 适用于终端的天气预报应用


### PR DESCRIPTION
Adds [taskwarrior](https://taskwarrior.org/) to the Applications section.

_Taskwarrior is Free and Open Source Software that manages your TODO list from the command line. It is flexible, fast, and unobtrusive. It does its job then gets out of your way._

The translation might be a bit dodgy.

Cheers.
