### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 
 * [ansiweather](https://github.com/fcambus/ansiweather) - Weather in your terminal, with ANSI colors and Unicode symbols
 * [bashblog](https://github.com/cfenollosa/bashblog) - A Bash script that handles blog posting
-* [choosealicense-cli](https://github.com/lord63/choosealicense-cli) - Bring [`http://choosealicense.com`](https://choosealicense.com/) to your terminal
+* [choosealicense-cli](https://github.com/lord63/choosealicense-cli) - Bring [`https://choosealicense.com/`](https://choosealicense.com/) to your terminal
 * [facy](https://github.com/huydx/facy) - Command line power tool for facebook
 * [fanyi](https://github.com/afc163/fanyi) - Translate English to Chinese in terminal
 * [geeknote](https://github.com/VitaliyRodnenko/geeknote) - Command line evernote client


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Corrected URLs 
Was | Now 
--- | --- 
http://choosealicense.com | https://choosealicense.com/ 
