### PR TITLE
Adding lf.sh (https://github.com/suewonjp/lf.sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [hstr](https://github.com/dvorka/hstr) - Bash History Suggest Box
 * [k](https://github.com/supercrabtree/k) - k is a Zsh script to make directory listings more readable, adding Git status, fileweight colors and rotting dates
 * [k alias](https://github.com/lingtalfi/k) - get kool aliases (and more) working with a simple one-liner
+* [lf.sh](https://github.com/suewonjp/lf.sh) - Quickly search files with fewer typings and do many more (grepping, copying path to clipboard, etc)
 * [marker](https://github.com/pindexis/marker) - Bookmark your shell commands
 * [modules](http://modules.sourceforge.net/) - Environment manager for the shell (compare to direnv and autoenv)
 * [nnn](https://github.com/jarun/nnn) - File browser and disk usage analyzer with excellent desktop integration


### PR DESCRIPTION
lf.sh (https://github.com/suewonjp/lf.sh) is a Bash utility to help you quickly search arbitrary files or search text from files.

It's more convenient and intuitive to use than `ls` or find `command`. 
(It is inspired by z - https://github.com/rupa/z)

Full documentation is ready at https://github.com/suewonjp/lf.sh/wiki
