### PR TITLE
Added doclt to the list of developer tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [bcal](https://github.com/jarun/bcal) - Byte CALculator for storage conversions and calculations
 * [bocker](https://github.com/p8952/bocker) - Docker implemented in 100 lines of bash
 * [cloc](https://github.com/AlDanial/cloc) - Count Lines of Code
+* [doclt](https://github.com/omgimanerd/doclt) - A command line interface to Digital Ocean
 * [dokku](https://github.com/dokku/dokku) - Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen.
 * [getopts](https://github.com/fisherman/getopts) - CLI parser for fish
 * [git-extra-commands](https://github.com/unixorn/git-extra-commands) - Many Git extra utilities. Churn, cut-branch, improved-merge and many more.


### PR DESCRIPTION
[doclt](https://github.com/omgimanerd/doclt) is a CLI that allows for developers to interact with Digital Ocean from the command line to provision droplets, manage volumes, etc.