### PR TITLE
mplayer -> mpv

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [image-scraper](https://github.com/sananth12/ImageScraper) - A cool command line image scraper with a lot of features.
 * [imgp](https://github.com/jarun/imgp) - Blazing fast batch image resizer and rotator
 * [jq](https://github.com/stedolan/jq) - Sed for json data. You can use it to slice and filter and map and transform structured data
-* [mplayer](http://www.mplayerhq.hu/design7/news.html) - Lets you play most audio and video formats (using ASCII characters) in the shell as well as in a GUI.
+* [mpv](https://mpv.io/) - Lets you play most audio and video formats (using ASCII characters) in the shell as well as in a GUI.
 * [nehm](https://github.com/bogem/nehm) - Console tool, which downloads, sets IDv3 tags and adds to your iTunes (if you use it) your SoundCloud likes in convenient way
 * [PiCAST](https://github.com/lanceseidman/PiCAST) - PiCAST turns your $35 Raspberry Pi in to a Chromecast like Device
 * [sejda](https://github.com/torakiki/sejda/) - Command line manipulation of PDF documents (split, merge, rotate, convert to jpg, extract text, etc)


### PR DESCRIPTION
mpv is an mplayer2 fork that's seen much more development. From https://mpv.io/:

> mpv is a fork of mplayer2 and MPlayer. It shares some features with the former projects while introducing many more.

Notably, you can watch youtube videos in the shell via
```
DISPLAY= mpv --quiet -vo caca 'https://www.youtube.com/watch?v=bvYgBty6nJs'
```