### PR TITLE
Added getnews.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [facy](https://github.com/huydx/facy) - Command line power tool for facebook
 * [fanyi](https://github.com/afc163/fanyi) - Translate English to Chinese in terminal
 * [geeknote](https://github.com/VitaliyRodnenko/geeknote) - Command line evernote client
+* [getnews.tech](https://github.com/omgimanerd/getnews.tech) - Browse various news outlets on the web from your terminal.
 * [haxor-news](https://github.com/donnemartin/haxor-news) - Browse Hacker News like a haxor
 * [hn-cli](https://github.com/rafaelrinaldi/hn-cli) - Browse Hacker News from the comfort of your Terminal
 * [iponmap](https://github.com/nogizhopaboroda/iponmap) - Draw point on world map using ip address


### PR DESCRIPTION
getnews.tech is a command line utility powered by the News API that allows you to browse news from over 70 worldwide news outlets on the web.