### PR TITLE
Add hss

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [has](https://github.com/kdabir/has) - `has` helps you check presence of various command line tools and their versions on path
 * [hhighlighter](https://github.com/paoloantinori/hhighlighter) - Colorize words in a command output
 * [hr](https://github.com/LuRsT/hr) - `<hr />` for your terminal
+* [hss](https://github.com/six-ddc/hss) - An interactive parallel ssh client featuring autocomplete and asynchronous execution
 * [hstr](https://github.com/dvorka/hstr) - Bash History Suggest Box
 * [jump](https://github.com/gsamokovarov/jump) - Jump helps you navigate your file system faster by learning your habits.
 * [k](https://github.com/supercrabtree/k) - k is a Zsh script to make directory listings more readable, adding Git status, fileweight colors and rotting dates

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -44,6 +44,7 @@
 * [fzf](https://github.com/junegunn/fzf) - 命令行下的模糊搜索器
 * [hhighlighter](https://github.com/paoloantinori/hhighlighter) - 在命令输出中给单词着色
 * [hr](https://github.com/LuRsT/hr) - 适用于终端的 `<hr />`
+* [hss](https://github.com/six-ddc/hss) - 可交互的ssh批量执行客户端，具有自动完成远端路径和异步执行的特性
 * [hstr](https://github.com/dvorka/hstr) - Bash 历史建议框
 * [k](https://github.com/supercrabtree/k) - k 是一个使目录列表更可读的 Zsh 脚本，它增添了 Git 状态、文件颜色、以及腐朽的日期
 * [k alias](https://github.com/lingtalfi/k) - 获得用于单行的酷 alias


### PR DESCRIPTION
`hss` is an interactive ssh client for multiple servers. It will provide almost the same experience as in the bash environment. It supports:

* interactive input: based on [libreadline](https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html).
* history: responding to the `C-r` key.
* auto-completion: completion from remote server on the `tab` key, for commands and paths.

Command is executed on all servers in parallel. Execution on one server does not need to wait for that on another server to finish before starting. So we can run a command on hundreds of servers at the same time.

`hss` can be switched between the `remote` mode and the `inner` mode when the `Esc` key is typed. In the `inner` mode, we can

* add or remove a server dynamically.
* download or upload files.
* reconfigure the environments.
* and do something more in the future versions.