### PR TITLE
Add xiringuito - SSH-based "VPN for poors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [powertop](https://github.com/fenrus75/powertop) - Battery/Power usage and device stats monitoring command-line tool, with tune-up options.
 * [procdog](https://github.com/jlevy/procdog) - Lightweight command-line control of long-lived processes like servers
 * [quick-secure](https://github.com/marshyski/quick-secure) - Quickly secure and harden UNIX/Linux systems
+* [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based "VPN for poors"
 
 ## Downloading and Serving
 


### PR DESCRIPTION
This adds xiringuito - SSH-based "VPN for poors"

# WHY?
`xiringuito` is awesome, because:
* easy to install (no dependencies, no configurations)
* allows you to manage one, few or many connections easily (and connect em simultaneously if you want)
* it has `xaval` connection manager - a tool that may record and later re-use your connection profiles
* though you are free to use or not to use `xaval` connection manager - people also use `xiringuito` for ad-hoc onetime connections
* Just look at this GIF :wink: 
![](https://github.com/ivanilves/xiringuito/raw/master/images/install.gif)
