### PR TITLE
Changes `sstephenson/bats` to `bats-core/bats-core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [bashful](https://github.com/jmcantrell/bashful) - A collection of libraries to simplify writing Bash scripts
 * [bashmanager](https://github.com/lingtalfi/bashmanager) - mini bash framework for creating command line tools
 * [bashwithnails](https://github.com/mindaugasbarysas/bashwithnails) - a Bash framework written just for fun with testing, dependency management & packaging
-* [bats](https://github.com/sstephenson/bats) - Bash Automated Testing System
+* [bats](https://github.com/bats-core/bats-core) - Bash Automated Testing System
 * [crash](https://github.com/molovo/crash) - Proper error handling, exceptions and try/catch for ZSH
 * [Fishtape](https://github.com/fisherman/fishtape) - TAP producer and test harness for fish
 * [composure](https://github.com/erichs/composure) - Compose, document, version and organize your shell functions

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -229,7 +229,7 @@
 * [assert.sh](https://github.com/lehmannro/assert.sh) - Bash 单元测试框架
 * [bashful](https://github.com/jmcantrell/bashful) - 简化编写 Bash 脚本的库收集
 * [bashmanager](https://github.com/lingtalfi/bashmanager) - 用来创建命令行工具的微型 Bash 框架
-* [bats](https://github.com/sstephenson/bats) - Bash 自动化测试系统
+* [bats](https://github.com/bats-core/bats-core) - Bash 自动化测试系统
 * [Fishtape](https://github.com/fisherman/fishtape) - 适用于 fish 的 TAP 产生器及测试工具
 * [composure](https://github.com/erichs/composure) - 撰写、文档、版本、及组织你的 shell 函数
 * [dispatch](https://github.com/Mosai/workshop/blob/master/doc/dispatch.md) - 使用 50 行可移植 shell 脚本写成的命令行参数解析器


### PR DESCRIPTION
As [active development of BATS has moved](https://github.com/sstephenson/bats/issues/236) to [`bats-core`](https://github.com/bats-core/bats-core), it seemed prudent to change mentions of `sstephenson/bats` to `bats-core/bats-core`.