### PR TITLE
Added hblock to system utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [stronghold](https://github.com/alichtman/stronghold) - Easily configure MacOS security settings from the terminal.
 * [glances](https://github.com/nicolargo/glances) - Glances an Eye on your system
 * [goaccess](https://github.com/allinurl/goaccess) - GoAccess is a real-time web log analyzer and interactive viewer that runs in a terminal in \*nix systems.
-* [hblock](https://github.com/zant95/hblock) - Hosts-file based adblocker
+* [hblock](https://github.com/hectorm/hblock) - Hosts-file based adblocker
 * [histstat](https://github.com/vesche/histstat) - History for netstat
 * [htop](https://github.com/hishamhm/htop) - A ncurses based interactive process viewer which aims to be a better `top`
 * [lnav](http://lnav.org) - An advanced log file viewer for the small-scale

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [stronghold](https://github.com/alichtman/stronghold) - Easily configure MacOS security settings from the terminal.
 * [glances](https://github.com/nicolargo/glances) - Glances an Eye on your system
 * [goaccess](https://github.com/allinurl/goaccess) - GoAccess is a real-time web log analyzer and interactive viewer that runs in a terminal in \*nix systems.
+* [hblock](https://github.com/zant95/hblock) - Hosts-file based adblocker
 * [histstat](https://github.com/vesche/histstat) - History for netstat
 * [htop](https://github.com/hishamhm/htop) - A ncurses based interactive process viewer which aims to be a better `top`
 * [lnav](http://lnav.org) - An advanced log file viewer for the small-scale


### PR DESCRIPTION
[hBlock](https://github.com/zant95/hblock) is a POSIX-compliant shell script that gets a list of domains that serve ads, tracking scripts and malware from multiple sources and creates a hosts file that prevents the system from connecting to them. I think that this tool can be useful in the system utilities section.

**Disclaimer:** I'm the author of the project.