### PR TITLE
Add wifi-wand, a Ruby utility for managing WiFi on Mac OS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [powertop](https://github.com/fenrus75/powertop) - Battery/Power usage and device stats monitoring command-line tool, with tune-up options.
 * [procdog](https://github.com/jlevy/procdog) - Lightweight command-line control of long-lived processes like servers
 * [quick-secure](https://github.com/marshyski/quick-secure) - Quickly secure and harden UNIX/Linux systems
-* [wifi-wand](https://github.com/keithrbennett/wifiwand) - a Ruby executable for managing WiFi on MacOS (install by `gem install wifi-wand`)
+* [wifi-wand](https://github.com/keithrbennett/wifiwand) - a Ruby command line application for managing WiFi on MacOS (install by `gem install wifi-wand`)
 * [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based "VPN for poors"
 
 ## Downloading and Serving

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [powertop](https://github.com/fenrus75/powertop) - Battery/Power usage and device stats monitoring command-line tool, with tune-up options.
 * [procdog](https://github.com/jlevy/procdog) - Lightweight command-line control of long-lived processes like servers
 * [quick-secure](https://github.com/marshyski/quick-secure) - Quickly secure and harden UNIX/Linux systems
+* [wifi-wand](https://github.com/keithrbennett/wifiwand) - a Ruby executable for managing WiFi on MacOS (install by `gem install wifi-wand`)
 * [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based "VPN for poors"
 
 ## Downloading and Serving


### PR DESCRIPTION
Add entry for wifi-wand command line application for managing WiFi on Mac OS.