### PR TITLE
Fixes #272 by Pointing mr and surfraw link to new url

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [git-up](https://github.com/aanand/git-up) - Automatically rebase incoming changes instead of merging. Be polite!
 * [hub](https://github.com/github/hub) - hub helps you win at git.
 * [licins](https://github.com/dogoncouch/licins) - Insert commented software licenses into source code.
-* [mr](https://github.com/joeyh/myrepos) - Multiple Repository management tool
+* [mr](https://myrepos.branchable.com) - Multiple Repository management tool
 * [overcommit](https://github.com/brigade/overcommit) - A fully configurable and extendable Git hook manager
 * [pre-commit](https://pre-commit.com) - A framework for managing and maintaining multi-language pre-commit hooks
 * [rebound](https://github.com/shobrook/rebound) - Instantly browse Stack Overflow results in your terminal when you get a compiler error

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [sshfs](https://github.com/osxfuse/sshfs) - A tool for mounting remote file systems over SSH
 * [sshrc](https://github.com/Russell91/sshrc) - Bring your .bashrc, .vimrc, etc. with you when you SSH
 * [sudocabulary](https://github.com/badarsh2/Sudocabulary) - Learn English Vocabulary from your terminal
-* [surfraw](http://surfraw.alioth.debian.org/) - browse specific site and search the web from your terminal without browser.
+* [surfraw](https://gitlab.com/surfraw/Surfraw) - browse specific site and search the web from your terminal without browser.
 * [task-manager](https://github.com/lingtalfi/task-manager) - Execute all your scripts with just two or three keystrokes.
 * [thefuck](https://github.com/nvbn/thefuck) - Fix common shell mistakes by using an easy to remember command
 * [tldr](https://github.com/raylee/tldr) - A fully-functional bash client for tldr, simplified and community-driven man pages

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -110,7 +110,7 @@
 * [git-sh](https://github.com/rtomayko/git-sh) - 适合 Git 工作的定制 Bash 环境
 * [git-up](https://github.com/aanand/git-up) - 自动变基进来的更改代替合并，优雅！
 * [hub](https://github.com/github/hub) - 更易使用 GitHub 的命令行工具
-* [mr](https://github.com/joeyh/myrepos) - 多仓库管理工具
+* [mr](https://myrepos.branchable.com) - 多仓库管理工具
 * [overcommit](https://github.com/brigade/overcommit) - 完全可配置且可扩展的 Git hook 管理器
 * [pre-commit](https://pre-commit.com) - 用于管理及维护多语言 pre-commit hooks 的框架
 * [repren](https://github.com/jlevy/repren) - 命令行搜索与替换及文件重命名的瑞士军刀式工具


### PR DESCRIPTION
Fixes #272 

It appears that the mr repo was deleted from github. I've updated it to the homepage.