### PR TITLE
Added shell2http

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [HTTPLab](https://github.com/gchaincl/httplab) - The interactive web server, let you inspect HTTP requests and forge responses.
 * [ngincat](https://github.com/jaburns/ngincat) - Tiny Bash HTTP server using netcat
 * [resty](https://github.com/micha/resty) - Little command line REST client that you can use in pipelines
+* [shell2http](https://github.com/msoap/shell2http) - HTTP-server to execute shell commands. Designed for development, prototyping or remote control
 * [youtube-dl](https://github.com/rg3/youtube-dl) - Small command-line program to download videos from YouTube.com and other video sites
 
 ## Multimedia and File Formats


### PR DESCRIPTION
This is a HTTP-server to execute shell commands. Designed for development, prototyping or remote control.