### PR TITLE
Add nmtui

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [rng](https://github.com/nickolasburr/rng) - Copy range of lines from file or stdin to stdout.
 * [wifi-wand](https://github.com/keithrbennett/wifiwand) - a Ruby command line application for managing WiFi on MacOS (install by `gem install wifi-wand`)
 * [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based "VPN for poors"
+* [nmtui](https://github.com/NetworkManager/NetworkManager) - Text User Interface for controlling NetworkManager
 
 ## Downloading and Serving
 


### PR DESCRIPTION
`nmtui` is a ncurses command-line network manager.
More details https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-configure_bonding_using_the_text_user_interface_nmtui
