### PR TITLE
Remove git-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [git-quick-stats](https://github.com/arzzen/git-quick-stats) - Git quick statistics is a simple and efficient way to access various statistics in git repository.
 * [git-semver](https://github.com/markchalloner/git-semver) - Git plugin for easing semantic versioning and changelog validation
 * [git-sh](https://github.com/rtomayko/git-sh) - A customized Bash environment suitable for Git work
-* [git-up](https://github.com/aanand/git-up) - Automatically rebase incoming changes instead of merging. Be polite!
 * [hub](https://github.com/github/hub) - hub helps you win at git.
 * [licins](https://github.com/dogoncouch/licins) - Insert commented software licenses into source code.
 * [mr](https://myrepos.branchable.com) - Multiple Repository management tool

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -109,7 +109,6 @@
 * [git-open](https://github.com/paulirish/git-open) - 输入 `git open` 在浏览器中打开 GitHub 页面或仓库网站
 * [git-semver](https://github.com/markchalloner/git-semver) - 用来方便的语义化版本及更改日志验证的 Git 插件
 * [git-sh](https://github.com/rtomayko/git-sh) - 适合 Git 工作的定制 Bash 环境
-* [git-up](https://github.com/aanand/git-up) - 自动变基进来的更改代替合并，优雅！
 * [hub](https://github.com/github/hub) - 更易使用 GitHub 的命令行工具
 * [mr](https://myrepos.branchable.com) - 多仓库管理工具
 * [overcommit](https://github.com/brigade/overcommit) - 完全可配置且可扩展的 Git hook 管理器


### PR DESCRIPTION
Per the [warning on the now unmaintained GitHub page](https://github.com/aanand/git-up#warning), `git-up` is obsolete, no longer maintained, and carries a recommendation _against_ using it from the former maintainer. Let's remove it.