### PR TITLE
Add fast_cd_menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [direnv](https://github.com/direnv/direnv) - An environment switcher for the shell, compare with autoenv
 * [enhancd](https://github.com/b4b4r07/enhancd) - :rocket: A next-generation cd command with an interactive filter
 * [fasd](https://github.com/clvv/fasd) - Command-line productivity booster, offers quick access to files and directories
+* [fast_cd_menu](https://github.com/xhawk18/fast_cd_menu) - cd history menu implemented by bash
 * [fd](https://github.com/sharkdp/fd) - A simple, fast and user-friendly alternative to find.
 * [foxy](https://github.com/s-p-k/foxy) - Plain text bookmarks for firefox and surf browsers.
 * [fselect](https://github.com/jhspetersson/fselect) - Find files with SQL-like queries.

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -40,6 +40,7 @@
 * [direnv](https://github.com/direnv/direnv) - 针对 shell 的环境切换工具（利用 autoenv 比较）
 * [enhancd](https://github.com/b4b4r07/enhancd) - :rocket: 具有交互式过滤功能的下一代 cd 命令
 * [fasd](https://github.com/clvv/fasd) - 命令行效率提升器，提供快速访问文件及目录
+* [fast_cd_menu](https://github.com/xhawk18/fast_cd_menu) - 菜单形式快速进入cd历史目录（纯bash实现）
 * [foxy](https://github.com/s-p-k/foxy) - 适合 Firefox 及 Surf 浏览器的无格式文本书签
 * [fz](https://github.com/changyuheng/fz) - z 的无缝模糊补全
 * [fzf](https://github.com/junegunn/fzf) - 命令行下的模糊搜索器


### PR DESCRIPTION
[fast_cd_menu](https://github.com/xhawk18/fast_cd_menu) is a bash script to support command "c" in bash to show cd history as menu.
![screen snapshot](https://github.com/xhawk18/fast_cd_menu/raw/master/screen.gif)