### PR TITLE
add: z.lua - A new cd command that helps you navigate faster by learning your habits

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [wemux](https://github.com/zolrath/wemux) - Multi-User Tmux Made Easy
 * [xsv](https://github.com/BurntSushi/xsv) - a fast CSV command line toolkit written in Rust
 * [z](https://github.com/rupa/z) - z is the new j, yo
+* [z.lua](https://github.com/skywind3000/z.lua) - A new cd command that helps you navigate faster by learning your habits
 
 ## Customization
 

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -75,6 +75,7 @@
 * [v](https://github.com/rupa/v) - 适用于 Vim 的 z
 * [wemux](https://github.com/zolrath/wemux) - 多用户使用 Tmux 变得更容易
 * [z](https://github.com/rupa/z) - z 是新的 j
+* [z.lua](https://github.com/skywind3000/z.lua) - 一个会学习你使用习惯的快速 cd 命令
 
 ## 定制
 


### PR DESCRIPTION
Features of [z.lua](https://github.com/skywind3000/z.lua):

- **10x** times faster than **fasd** and **autojump**, **3x** times faster than **z.sh**.
- Available for **posix shells**: bash, zsh, dash, sh, ash, busybox and etc.
- Available for Fish Shell, Power Shell and Windows cmd.
- Enhanced matching mode takes you to where ever you want precisely.
- Allow updating database only if `$PWD` changed with "$_ZL_ADD_ONCE" set to 1.
- Interactive selection enables you to choose where to go before cd.
- Interactive selection with FZF (optional).
- Quickly go back to a parent directory instead of typing "cd ../../..".
- Corresponding experience in different shells and operating systems. 
- Compatible with Lua 5.1, 5.2 and 5.3+
- Self contained, distributed as a single `z.lua` script, no other dependence.


People using z.lua said:

- "I like this in principal. I’m pretty damn predictable at the command line and far too lazy to make shortcuts"
- "It feels far more intuitive and it's so incredibly convenient to be able to jump between folders I'm working in without having to traverse an entire tree. The shell used to feel so constraining for me, but tools like this are making me enjoy it so much more. "
- "I can finally have autojump-like functionality on my Raspberry Pi 1 without waiting 30 seconds every time I open a new shell. Thanks z.lua devs."
- "Anyway, z.lua is a promising project. If you only need directory jumping, it may be the best choice."