### PR TITLE
Add td-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [sudocabulary](https://github.com/badarsh2/Sudocabulary) - Learn English Vocabulary from your terminal
 * [surfraw](https://gitlab.com/surfraw/Surfraw) - browse specific site and search the web from your terminal without browser.
 * [task-manager](https://github.com/lingtalfi/task-manager) - Execute all your scripts with just two or three keystrokes.
+* [td-cli](https://github.com/darrikonn/td-cli) - A todo command line manager to organize and manage your todos across multiple projects.
 * [thefuck](https://github.com/nvbn/thefuck) - Fix common shell mistakes by using an easy to remember command
 * [tldr](https://github.com/raylee/tldr) - A fully-functional bash client for tldr, simplified and community-driven man pages
 * [tmux](http://tmux.github.io/) - Amazing terminal multiplexer
@@ -126,8 +127,6 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [wemux](https://github.com/zolrath/wemux) - Multi-User Tmux Made Easy
 * [xsv](https://github.com/BurntSushi/xsv) - a fast CSV command line toolkit written in Rust
 * [z](https://github.com/rupa/z) - z is the new j, yo
-* [td-cli](https://github.com/darrikonn/td-cli) - A todo command line manager to organize and manage your todos across multiple projects.
-
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [wemux](https://github.com/zolrath/wemux) - Multi-User Tmux Made Easy
 * [xsv](https://github.com/BurntSushi/xsv) - a fast CSV command line toolkit written in Rust
 * [z](https://github.com/rupa/z) - z is the new j, yo
-* [td-cli](https://github.com/darrikonn/td-cli) - A todo command-line manager to organize and manage your todos across multiple projects.
+* [td-cli](https://github.com/darrikonn/td-cli) - A todo command line manager to organize and manage your todos across multiple projects.
 
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [wemux](https://github.com/zolrath/wemux) - Multi-User Tmux Made Easy
 * [xsv](https://github.com/BurntSushi/xsv) - a fast CSV command line toolkit written in Rust
 * [z](https://github.com/rupa/z) - z is the new j, yo
+* [td-cli](https://github.com/darrikonn/td-cli) - A todo command-line manager to organize and manage your todos across multiple projects.
+
 
 ## Customization
 

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -75,6 +75,7 @@
 * [v](https://github.com/rupa/v) - 适用于 Vim 的 z
 * [wemux](https://github.com/zolrath/wemux) - 多用户使用 Tmux 变得更容易
 * [z](https://github.com/rupa/z) - z 是新的 j
+* [td-cli](https://github.com/darrikonn/td-cli) - 组织者命令行管理器，用于跨多个项目组织和管理您的待办事项。
 
 ## 定制
 

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -69,13 +69,13 @@
 * [mosh](https://mosh.org) - 第一个实现SSP的应用，MIT的博士项目，使得C/S之间可以保持链接持续，即使断开还能恢复之前的状态
 * [sshrc](https://github.com/Russell91/sshrc) - SSH 时带上你的 .bashrc、.vimrc 等
 * [sudocabulary](https://github.com/badarsh2/Sudocabulary) - 从终端学习英语词汇
+* [td-cli](https://github.com/darrikonn/td-cli) - 组织者命令行管理器，用于跨多个项目组织和管理您的待办事项。
 * [thefuck](https://github.com/nvbn/thefuck) - 通过使用容易记住的命令修正常见的 shell 错误
 * [tmux](http://tmux.github.io/) - 很棒的终端复用器
 * [up](https://github.com/shannonmoeller/up) - 按名称或计数升序排列目录，支持 bash 和 zsh
 * [v](https://github.com/rupa/v) - 适用于 Vim 的 z
 * [wemux](https://github.com/zolrath/wemux) - 多用户使用 Tmux 变得更容易
 * [z](https://github.com/rupa/z) - z 是新的 j
-* [td-cli](https://github.com/darrikonn/td-cli) - 组织者命令行管理器，用于跨多个项目组织和管理您的待办事项。
 
 ## 定制
 


### PR DESCRIPTION
## td-cli
Implements https://github.com/alebcay/awesome-shell/issues/316

### Link
https://github.com/darrikonn/td-cli

### Description
**td-cli** is a command line todo manager, 
where you can organise and manage your todos across multiple projects

### Why?
**td-cli** allows you to group your todos based on your projects and helps you keep your todos well organised and well structured.
**td-cli** also has an awesome interactive mode which speeds up the whole process!

### How to install
```bash
pip3 install td-cli
```