### PR TITLE
Add wipe-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [shipit](https://github.com/sapegin/shipit) - Minimalistic SSH deployment
 * [starring](https://github.com/ritz078/starring) - Automatically star the npm-packages that you are using on GitHub.
 * [tag](https://github.com/aykamko/tag) - Instantly jump to your ag matches.
+* [wipe-modules](https://github.com/bntzio/wipe-modules) - A little agent that removes the node_modules folder of non-active projects
 * [xtm](https://github.com/Camji55/xtm) - Command line tool that helps you manage your Xcode project templates.
 
 ## System Utilities


### PR DESCRIPTION
[wipe-modules](https://github.com/bntzio/wipe-modules) is a cli tool that removes the `node_modules` of your non-active projects, useful when you're running out of disk space or want to migrate your files to another computer, backups, etc.