### PR TITLE
Add now-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [licen](https://github.com/lord63/licen) - Generate your license. Yet another lice, but implement with Jinja2 and docopt
 * [md2png](https://github.com/weaming/md2png) - Convert markdown to PNG image
 * [moviemon](https://github.com/iCHAIT/moviemon) - Everything about your movies within the command line.
+* [now](https://zeit.co/now) - Makes serverless application deployment easy. Don’t spend time configuring the cloud. Just push your code.
 * [pockyt](https://github.com/arvindch/pockyt) - Read, Manage, and Automate your [Pocket](https://getpocket.com) collection.
 * [pushblast](https://github.com/alebcay/pushblast) - Get PushBullet notifications when a shell program exits
 * [pushbullet-bash](https://github.com/Red5d/pushbullet-bash) - Bash interface to the PushBullet API


### PR DESCRIPTION
# now-cli
The command-line interface for  Zeit Now.

### Link 
https://zeit.co/now

### Description
ZEIT Now is a cloud platform for serverless deployment. It enables developers to host websites and web services that deploy instantly, scale automatically, and require no supervision, all with minimal configuration.

### Why ?
Now makes serverless application deployment easy. Don’t spend time configuring the cloud. Just push your code.

### How to install
```
npm install -g now
```
