### PR TITLE
add Korn Shell variants and tcsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [xiki](http://xiki.org) - Makes the shell console more friendly and powerful
 * [xonsh](http://xonsh.org) - Python-ish, BASHwards-looking shell language and command prompt
 * [zsh](http://www.zsh.org) - Powerful shell with scripting language
+* [ksh93](https://github.com/att/ast) - Korn Shell
+* [pdksh](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/bin/ksh/) - Public domain Korn shell
+* [oksh](https://github.com/ibara/oksh) - Portable OpenBSD ksh
+* [mksh](https://github.com/MirBSD/mksh) - MirBSD Korn Shell
+* [tcsh](https://www.tcsh.org/) - C shell with file name completion and command line editing
 
 ## Command-Line Productivity
 


### PR DESCRIPTION
It seems remiss to exclude both Korn shell and its variants and tcsh, with an obvious bias to newer "exotic" shells compared to more historical ones which have had a much bigger impact and towards mac OS and Linux as compared to the BSDs. I think most of these are generally seen as relics but they are still relevant.

* The "original" Korn shell is still actively developed (https://github.com/att/ast)
* pdksh is the default shell on OpenBSD and is actively developed
* oksh is a portable version of pdksh and is actively developed
* MirBSD shell (mksh) is the default on Android and is actively developed (edit: MirBSD is no longer)
* tcsh is the default root shell of FreeBSD