### PR TITLE
Added cbf

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [borg](https://github.com/ok-borg/borg) - A terminal based search engine for bash commands
 * [Buku](https://github.com/jarun/Buku) - Powerful command-line bookmark manager
 * [byobu](http://byobu.co/) - Text-based window manager and terminal multiplexer
+* [cbf](https://github.com/joshuatvernon/cbf) - Build custom CLI apps with only a json or yaml file.
 * [commacd](https://github.com/shyiko/commacd) - A faster way to move around in Bash
 * [CloudClip](https://github.com/skywind3000/CloudClip) - Your own clipboard in the cloud, copy and paste text with gist between different systems
 * [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the terminal


### PR DESCRIPTION
Added cbf a CLI app for creating custom CLI apps. Very meta but very powerful. It allows developers to create very simple scripts in json or yaml that define how a CLI app will behave. Scripts can be stored in any repo to share with other team members or just stored in cbf directly for personal used. Cbf can also turn any package.json scripts section into a CLI app.