### PR TITLE
Add GROQ to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [xidel](https://github.com/benibela/xidel/) - Cli tool to filter, map and create HTML/XML/JSON data with (Turing-complete) XPath and XQuery.
 * [xmlstarlet](http://xmlstar.sourceforge.net/) - Old but powerful tool for command-line XML formatting, filtering, and manipulation.
 * [fx](https://github.com/antonmedv/fx) - Command-line JSON processing tool by anononymus JavaScript functions
+* [GROQ](https://github.com/sanity-io/groq-cli) – Powerful JSON processor. Query and project (ND)JSON documents from stdin.
 
 ## Applications
 


### PR DESCRIPTION
It's like SQL for JSON. You can query documents/objects to filter down to only those you need, and then project the result into the structure you want. The syntax is easier to learn and remember than other similar tools.