### PR TITLE
add vesper to as bash http framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [ngincat](https://github.com/jaburns/ngincat) - Tiny Bash HTTP server using netcat
 * [resty](https://github.com/micha/resty) - Little command line REST client that you can use in pipelines
 * [shell2http](https://github.com/msoap/shell2http) - HTTP-server to execute shell commands. Designed for development, prototyping or remote control
+* [vesper](https://github.com/chris-rock/vesper) - 🍸Vesper is a HTTP framework for Bash/Unix Shell
 * [youtube-dl](https://github.com/ytdl-org/youtube-dl) - Small command-line program to download videos from YouTube.com and other video sites
 
 ## Multimedia and File Formats


### PR DESCRIPTION
New App Submission

App name: vesper

Repo or homepage link: https://github.com/chris-rock/vesper

Description: 🍸Vesper - HTTP Framework for Bash Shell

Why you think it's awesome: Because it allows you to prototype web app with existing bash/shell command line tools