### PR TITLE
Add Gitmux link

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [percol](https://github.com/mooz/percol) - Adds flavor of interactive filtering to the traditional pipe concept of UNIX shell
 * [q](https://github.com/cal2195/q) - Vim like macro registers for your Bash and Zsh Shell
 * [qfc](https://github.com/pindexis/qfc) - File-completion widget for Bash and Zsh
+* [gitmux](https://github.com/arl/gitmux) - Show Git status in Tmux status bar
 * [rg](https://github.com/BurntSushi/ripgrep) - ripgrep is a line oriented search tool that combines the usability of The Silver Searcher with the raw speed of GNU grep
 * [screen](https://www.gnu.org/software/screen/) - GNU terminal multiplexer
 * [shell-history](https://github.com/pawamoy/shell-history) - Visualize your shell usage with Highcharts


### PR DESCRIPTION
First, thanks for doing that awesome list!
I'm the author and maintainer of https://github.com/arl/gitmux. Gitmux shows Git status in tmux status bar, it's a rewrite from scratch of https://github.com/arl/tmux-gitbar, which I also wrote. I rewrote it for various reasons, main ones being that it was written in bash script and it was becoming  increasingly difficult to maintain and add the features, plus it was only working with bash shells.
Gitmux however has already all the features it needs and is shell independent. 

Gitmux is shell-indepedent and some binaries for many platforms are pre-compiled and available as Github releases.
It's very stable and used everyday by many persons already, it has few stars since I published it like recently.
I believe gitmux is a good match with this list ;-)
I know the project only has 24 stars for now but tmux-gitbar (which is a rewrite of) had 160.