### PR TITLE
Add bashhub-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [aria2](https://github.com/aria2/aria2) - aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, BitTorrent and Metalink
 * [balls](https://github.com/jneen/balls) - Bash on Balls
 * [bashttpd](https://github.com/avleen/bashttpd) - A web server written in Bash
+* [bashhub-server](https://github.com/nicksherron/bashhub-server) - Private cloud shell history. Open source server for bashhub https://github.com/rcaloras/bashhub-client
 * [bitpocket](https://github.com/sickill/bitpocket) - "DIY Dropbox" or "2-way directory (r)sync with proper deletion"
 * [Dropbox-Uploader](https://github.com/andreafabrizi/Dropbox-Uploader) - Dropbox Uploader is a Bash script which can be used to upload, download, list or delete files from Dropbox
 * [httpie](https://github.com/jakubroztocil/httpie) - HTTPie is a command line HTTP client, a user-friendly cURL replacement


### PR DESCRIPTION
Adds Bashhub-server a server for bashhub-client which is already included in the list. It's gotten 99 stars in 3 days.