### PR TITLE
Add  dstask -- Single binary terminal-based TODO manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [carbon-now-cli](https://github.com/mixn/carbon-now-cli) - 🎨 Beautiful images of your code — from right inside your terminal.
 * [choosealicense-cli](https://github.com/lord63/choosealicense-cli) - Choose an OSS license from the comfort of your terminal
 * [cointop](https://github.com/miguelmota/cointop) - The fastest and most interactive terminal based UI application for tracking cryptocurrencies
+* [dstask](https://github.com/naggie/dstask) - Single binary terminal-based TODO manager with git-based sync + markdown notes per task
 * [facebook-cli](https://github.com/specious/facebook-cli) - Facebook command line tool
 * [fanyi](https://github.com/afc163/fanyi) - Translate English to Chinese in terminal
 * [gcalcli](https://github.com/insanum/gcalcli) - Google Calendar command line interface


### PR DESCRIPTION
Single binary terminal-based TODO manager with git-based sync + markdown notes per task 
Thanks!

https://github.com/naggie/dstask for more information.