### PR TITLE
Add starship shell prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [polyglot](https://github.com/agkozak/polyglot) - An informative Git prompt that works in bash, zsh, ksh, mksh, pdksh, dash, and busybox sh
 * [powerlevel10k](https://github.com/romkatv/powerlevel10k) - Super flexible awesome powerline ZSH theme
 * [sexy-bash-prompt](https://github.com/twolfson/sexy-bash-prompt) - Bash prompt with colors, Git statuses, and Git branches
+* [starship](https://starship.rs/) - Fast, customisable, cross-shell prompt written in rust
 * [synth-shell](https://github.com/andresgongora/synth-shell) - Greeter with a customizable status report and a fancy bash prompt
 
 ## For Developers


### PR DESCRIPTION
Added a cross-shell customisable prompt [starship](https://starship.rs/) to the list. Supports git statuses, custom plugins etc. Nice tool