### PR TITLE
Add cotp

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [Buku](https://github.com/jarun/Buku) - Powerful command-line bookmark manager
 * [byobu](https://www.byobu.org) - Text-based window manager and terminal multiplexer
 * [cod](https://github.com/dim-an/cod) — A completion daemon for shell that learns when you invoke `--help` commands
+* [cotp](https://github.com/replydev/cotp) - Trustworthy encrypted TOTP command line authenticator app compatible with multiple backups.
 * [CloudClip](https://github.com/skywind3000/CloudClip) - Your own clipboard in the cloud, copy and paste text with gist between different systems
 * [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the terminal
 * [desk](https://github.com/jamesob/desk) - A lightweight workspace manager for the shell


### PR DESCRIPTION
### **Description:**
cotp is a very simple two-factor authentication utility written in **rust** with **simplicity** and **efficiency** in mind. It relies in a single encrypted database file and has only the very important features to manage your codes, no useless stuff.

It can also import **backups** from [Aegis](https://github.com/beemdevelopment/Aegis), [andOTP](https://github.com/andOTP/andOTP), Authy and Google Authenticator.

### **Why you think it's awesome:**
I written this little app because i really wanted to manage my two factor authentication codes without using my phone and i didn't find any similar on the internet. 

So I thought I might not be the only one needing a utility like this, I hope someone appreciates this little work.
Thanks for reading this request.