### PR TITLE
Add `just` to "For Developers" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [git-semver](https://github.com/markchalloner/git-semver) - Git plugin for easing semantic versioning and changelog validation
 * [git-sh](https://github.com/rtomayko/git-sh) - A customized Bash environment suitable for Git work
 * [hub](https://github.com/github/hub) - hub helps you win at git.
+* [just](https://github.com/casey/just) - Task runner for saving and running project-specific commands.
 * [licins](https://github.com/dogoncouch/licins) - Insert commented software licenses into source code.
 * [mkdkr](https://github.com/rosineygp/mkdkr) - Makefile + Docker = CI Pipeline
 * [mr](https://myrepos.branchable.com) - Multiple Repository management tool


### PR DESCRIPTION
Just is a task runner, similar to make. I'm definitely biased, because I wrote it, but I think it's pretty awesome ^_^

It features:

- Excellent error messages
- Comprehensive documentation
- Lots of useful features
- Actively maintained
- Easy to install

Thank you for your consideration!