### PR TITLE
Add usql

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [tldr](https://github.com/raylee/tldr-sh-client) - A fully-functional bash client for tldr, simplified and community-driven man pages
 * [tmux](https://tmux.github.io/) - Amazing terminal multiplexer
 * [undollar](https://github.com/xtyrrell/undollar) - undollar bites the dollar sign off the tip of the command you just pasted into your terminal
+* [usql](https://github.com/xo/usql) - Universal command-line interface for SQL databases.
 * [v](https://github.com/rupa/v) - z for vim.
 * [wemux](https://github.com/zolrath/wemux) - Multi-User Tmux Made Easy
 * [xiki](https://xiki.org) - Makes the shell console more friendly and powerful


### PR DESCRIPTION
`usql` is an universal command-line interface for SQL databases, heavily inspired and mostly compatible with `psql`, but:
* is written in Go, which makes it easy to extend
* is distributed as fully static binaries, which makes it very portable
* supports most databases that have a Go driver, already including a few dozen different databases