### PR TITLE
Added Notes a GPG encrypted notes manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [mcfly](https://github.com/cantino/mcfly) - Fly through your shell history. Great Scot!
 * [modules](http://modules.sourceforge.net/) - Classical Tcl-based Environment Modules managing the shell environment (compare to Lmod, direnv, and autoenv)
 * [nnn](https://github.com/jarun/nnn) - File browser and disk usage analyzer with excellent desktop integration
+* [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for Unix/Linux 
 * [parallel](https://www.gnu.org/software/parallel/) - Build and execute shell command lines from standard input in parallel
 * [pass](https://www.passwordstore.org/) - Manage passwords from the command line with GPG encryption and optional git integration.
 * [pathpicker](https://github.com/facebook/PathPicker) - Accepts inputs like grep, searches, git etc; allows selecting files from the result of the input, which you can then open or provide as argument to a command.


### PR DESCRIPTION
Hi 

I've suggested Standard Unix Notes - a GPG encrypted ntoes/notebook manager that runs in any Unix/BSD/Linux etc that supports GnuPG. 

It is written in the Bourne shell avoiding Bash as that is not installed by default on some machines.