### PR TITLE
Add clenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [browsh](https://github.com/browsh-org/browsh) - The modern text-based browser
 * [Buku](https://github.com/jarun/Buku) - Powerful command-line bookmark manager
 * [byobu](https://www.byobu.org) - Text-based window manager and terminal multiplexer
+* [clenv](https://github.com/peterwwillis/clenv) - A tool to download, install, and run specific versions of programs in specific environments
 * [cod](https://github.com/dim-an/cod) — A completion daemon for shell that learns when you invoke `--help` commands
 * [CloudClip](https://github.com/skywind3000/CloudClip) - Your own clipboard in the cloud, copy and paste text with gist between different systems
 * [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the terminal


### PR DESCRIPTION
This adds the POSIX shell tool `clenv` - which sets up environment files and executes programs using them (optionally downloading specific versions of the programs first using plugins called "extensions").