### PR TITLE
add gh-f

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [doclt](https://github.com/omgimanerd/doclt) - A command line interface to Digital Ocean
 * [dokku](https://github.com/dokku/dokku) - Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen.
 * [forgit](https://github.com/wfxr/forgit) - Utility tool for `git` taking advantage of fuzzy finder fzf.
+* [gh-f](https://github.com/gennaro-tedesco/gh-f) - 🔎 the ultimate compact fzf gh extension.
 * [git-extra-commands](https://github.com/unixorn/git-extra-commands) - Many Git extra utilities. Churn, cut-branch, improved-merge and many more.
 * [git-extras](https://github.com/tj/git-extras) - Git utilities -- repo summary, repl, changelog population, author commit percentages and more
 * [git-open](https://github.com/paulirish/git-open) - Type `git open` to open the GitHub page or website for a repository in your browser


### PR DESCRIPTION
I have written a gh extension that I would like to add to the list: gh-f, a compact and snappy wrapper around gh basic functionalities that makes use of fzf and its properties.

Feel free to ignore if you deem it irrelevant :)
