### PR TITLE
Add `nve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [licins](https://github.com/dogoncouch/licins) - Insert commented software licenses into source code.
 * [mkdkr](https://github.com/rosineygp/mkdkr) - Makefile + Docker = CI Pipeline
 * [mr](https://myrepos.branchable.com) - Multiple Repository management tool
+* [nve](https://github.com/ehmicky/nve) - Run any command on specific Node.js versions.
 * [overcommit](https://github.com/sds/overcommit) - A fully configurable and extendable Git hook manager
 * [pre-commit](https://pre-commit.com) - A framework for managing and maintaining multi-language pre-commit hooks
 * [rebound](https://github.com/shobrook/rebound) - Instantly browse Stack Overflow results in your terminal when you get a compiler error


### PR DESCRIPTION
This adds [`nve`](https://github.com/ehmicky/nve), which allows running any terminal command with any Node.js version.
Unlike `nvm`, which is Bash specific, it works with any shell.