### PR TITLE
Update readme: mention render for Command Line Interface Pages project

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [Buku](https://github.com/jarun/Buku) - Powerful command-line bookmark manager
 * [byobu](https://www.byobu.org) - Text-based window manager and terminal multiplexer
 * [cod](https://github.com/dim-an/cod) — A completion daemon for shell that learns when you invoke `--help` commands
+* [clip-view](https://github.com/command-line-interface-pages/v2-tooling/tree/main/clip-view) — A render for [Command Line Interface Pages](https://command-line-interface-pages.github.io/site.github.io/about/)
 * [CloudClip](https://github.com/skywind3000/CloudClip) - Your own clipboard in the cloud, copy and paste text with gist between different systems
 * [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the terminal
 * [desk](https://github.com/jamesob/desk) - A lightweight workspace manager for the shell


### PR DESCRIPTION
[Here](https://command-line-interface-pages.github.io/site.github.io/about/) is a project site. This project very similar to TlDr but evolving in a different direction: more expressive syntax and more automation.

![image](https://user-images.githubusercontent.com/42812113/225377075-cbc3ef1a-be9d-4cc3-a265-9c7bf364e34a.png)

;)