### PR TITLE
readme: Add link to `awesome-bash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 - [Guides](#guides)
 - [**Awesome Zsh**][awesome-zsh]&nbsp; [![Awesome][awesome-badge]][awesome-zsh]
 - [**Awesome Fish**][awesome-fish] [![Awesome][awesome-badge]][awesome-fish]
+- [**Awesome Bash**][awesome-bash] [![Awesome][awesome-badge]][awesome-bash]
 - [Other Awesome Lists](#other-awesome-lists)
 
 ## Shells
@@ -460,9 +461,11 @@ Other amazingly awesome lists can be found in [awesome-awesome](https://github.c
 * [awesome-cli-apps](https://github.com/agarrharr/awesome-cli-apps)
 * [awesome-fish][awesome-fish]
 * [awesome-zsh][awesome-zsh]
+* [awesome-bash][awesome-bash]
 * [terminals-are-sexy](https://github.com/k4m4/terminals-are-sexy)
 
 [awesome-badge]: https://raw.githubusercontent.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
 [awesome-fish]: https://github.com/jorgebucaran/awsm.fish
 [awesome-link]: https://github.com/sindresorhus/awesome
 [awesome-zsh]: https://github.com/unixorn/awesome-zsh-plugins
+[awesome-bash]: https://github.com/awesome-lists/awesome-bash

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -15,6 +15,7 @@
 - [指南](#指南)
 - [**Awesome Zsh**][awesome-zsh]&nbsp; [![Awesome][awesome-badge]][awesome-zsh]
 - [**Awesome Fish**][awesome-fish] [![Awesome][awesome-badge]][awesome-fish]
+- [**Awesome Bash**][awesome-bash] [![Awesome][awesome-badge]][awesome-bash]
 - [其它 Awesome 清单](#其它-awesome-清单)
 
 ## 命令行效率
@@ -278,3 +279,4 @@
 [awesome-fish]: https://github.com/jorgebucaran/awsm.fish
 [awesome-link]: https://github.com/sindresorhus/awesome
 [awesome-badge]: https://raw.githubusercontent.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
+[awesome-bash]: https://github.com/awesome-lists/awesome-bash


### PR DESCRIPTION
There are links to `awesome-zsh` and `awesome-fish` - this adds one for Bash. Disclaimer: I help maintain that project.