### PR TITLE
Add bashunit: testing library for bash scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [bashwithnails](https://github.com/mindaugasbarysas/bashwithnails) - a Bash framework written just for fun with testing, dependency management & packaging
 * [bash-language-server](https://github.com/bash-lsp/bash-language-server) - [LSP](https://microsoft.github.io/language-server-protocol/)-based Bash language server
 * [bash-modules](https://github.com/vlisivka/bash-modules) - functions for developing with [unofficial strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) enabled.
+* [bashunit](https://github.com/TypedDevs/bashunit) - A simple but powerful testing library for bash scripts
 * [bats](https://github.com/bats-core/bats-core) - Bash Automated Testing System
 * [composure](https://github.com/erichs/composure) - Compose, document, version and organize your shell functions
 * [crash](https://github.com/molovo/crash) - Proper error handling, exceptions and try/catch for ZSH


### PR DESCRIPTION
## 📚 Description

**bashunit** is a dedicated testing tool crafted specifically for Bash scripts. It empowers you with tests on your Bash codebase, ensuring that your scripts operate reliably and as intended.

Homepage: https://bashunit.typeddevs.com 
GitHub: https://github.com/TypedDevs/bashunit

- [x] I've read the [contribution guidelines](https://github.com/alebcay/awesome-shell/blob/master/CONTRIBUTING.md).
  - [x] It's free and [open source license](https://github.com/TypedDevs/bashunit/blob/main/LICENSE).
  - [x] Easy to [install](https://bashunit.typeddevs.com/getting-started#installation), and well [documented](https://bashunit.typeddevs.com/assertions).
  - [x] With an [active community and engaged ownership](https://github.com/TypedDevs/bashunit/pulse).
