### PR TITLE
Add link to `git-scripts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [forgit](https://github.com/wfxr/forgit) - Utility tool for `git` taking advantage of fuzzy finder fzf.
 * [git-extra-commands](https://github.com/unixorn/git-extra-commands) - Many Git extra utilities. Churn, cut-branch, improved-merge and many more.
 * [git-extras](https://github.com/tj/git-extras) - Git utilities -- repo summary, repl, changelog population, author commit percentages and more
+* [git-scripts](https://github.com/jwiegley/git-scripts) - A bunch of random scripts written, downloaded, or clipped from #git.
 * [git-open](https://github.com/paulirish/git-open) - Type `git open` to open the GitHub page or website for a repository in your browser
 * [git-quick-stats](https://github.com/arzzen/git-quick-stats) - Git quick statistics is a simple and efficient way to access various statistics in git repository.
 * [git-semver](https://github.com/markchalloner/git-semver) - Git plugin for easing semantic versioning and changelog validation


### PR DESCRIPTION
[git-scripts](https://github.com/jwiegley/git-scripts) is a good resource that contains many git-specific scripts that are useful.