### PR TITLE
Removed YT downloader link.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ jobs:
 
       - name: Check links
         id: lychee
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@v1.8.0
         with:
           args: README.md README_ZH-CN.md --verbose --no-progress --exclude wiki.bash-hackers.org/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check lychee exit code
+        if: env.lychee_exit_code !=0
         run: exit ${lychee_exit_code}

--- a/README.md
+++ b/README.md
@@ -286,7 +286,6 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [shell2http](https://github.com/msoap/shell2http) - HTTP-server to execute shell commands. Designed for development, prototyping or remote control
 * [vesper](https://github.com/chris-rock/vesper) - 🍸Vesper is a HTTP framework for Bash/Unix Shell
 * [xh](https://github.com/ducaale/xh) - Friendly and fast tool for sending HTTP requests
-* [youtube-dl](https://yt-dl.org/) - Small command-line program to download videos from YouTube.com and other video sites
 
 ## Multimedia and File Formats
 

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -153,7 +153,6 @@
 * [http-server](https://www.npmjs.com/package/http-server) - http-server可以启动一个轻量级的http服务
 * [ngincat](https://github.com/jaburns/ngincat) - 使用 netcat 的微型 Bash HTTP 服务器
 * [resty](https://github.com/micha/resty) - 你可以在管道中使用的小型命令行 REST 客户端
-* [youtube-dl](https://yt-dl.org/) - 从 YouTube.com 及其它视频站点下载视频的小命令行程序
 * [coursera-dl](https://github.com/coursera-dl/coursera-dl) - 从Course公开课上下载视频
 
 ## 多媒体与文件格式


### PR DESCRIPTION
Apparently GitHub no longer allows https://yt-dl.org "for legal reasons". I upgraded it to the 1.8.x version of the lychee checker and removed the links from both versions of the README files and it started working after that.