### PR TITLE
Add logdy-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [trunk](https://www.npmjs.com/package/@trunkio/launcher) - Blazingly fast meta code checker and formatter
 * [vmn](https://github.com/final-israel/vmn) - git-based automatic versioning and state recovery solution agnostic to language or architecture
 * [wipe-modules](https://github.com/bntzio/wipe-modules) - A little agent that removes the node_modules folder of non-active projects
+* [logdy-core](https://github.com/logdyhq/logdy-core) - Supercharge logs with web UI
 
 ## System Utilities
 


### PR DESCRIPTION
Addition of [logdy](https://logdy.dev)

```
$ logdy stdin "tail -f file.log"
WebUI started, visit http://localhost:8080    port=8080
```
All lines from `tail -f` will be forwarded to a web UI
![](https://logdy.dev/filter.png)

Supercharge terminal logs with web browser UI and low-code.
It's like jq, tail, less, grep and awk merged together and available in a clean UI. Self-hosted, single binary.