### PR TITLE
Update htop project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [goaccess](https://github.com/allinurl/goaccess) - GoAccess is a real-time web log analyzer and interactive viewer that runs in a terminal in \*nix systems.
 * [hblock](https://github.com/hectorm/hblock) - Hosts-file based adblocker
 * [histstat](https://github.com/vesche/histstat) - History for netstat
-* [htop](https://github.com/hishamhm/htop) - A ncurses based interactive process viewer which aims to be a better `top`
+* [htop](https://github.com/htop-dev/htop) - A ncurses based interactive process viewer which aims to be a better `top`
 * [lnav](https://lnav.org) - An advanced log file viewer for the small-scale
 * [logdissect](https://github.com/dogoncouch/logdissect) - CLI utility and Python API for analyzing log files and other data.
 * [ls++](https://github.com/trapd00r/ls--) - Colorized ls on steroids


### PR DESCRIPTION
The previous link is now obsolete and refers to an archived repository.