### PR TITLE
add x-cmd to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [xplr](https://github.com/sayanarijit/xplr) -  A hackable, minimal, fast TUI file explorer
 * [xsv](https://github.com/BurntSushi/xsv) - a fast CSV command line toolkit written in Rust
 * [xxh](https://github.com/xxh/xxh) - Bring your favorite shell wherever you go through the SSH.
+* [x-cmd](https://github.com/x-cmd/x-cmd) - A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.
 
 ### Directory Navigation
 


### PR DESCRIPTION
Hi. Thank you for this collection of useful terminal programs!
I want to add x-cmd to the list.

x-cmd is a toolset implemented using posix shell and awk. It is very small in size and offers many interesting features.

**Tools Provided by x-cmd:**
  - [Wrappers for Common Commands (e.g., cd, ip, ps, tar, apt, brew)](https://x-cmd.com/mod/zuz): These wrapped commands are more intelligent and easier to use compared to the native commands.
  - [Lightweight Package Management Tool](https://x-cmd.com/pkg/): We have implemented a lightweight package management tool using shell and awk. Through it, you can quickly obtain most common software tools, such as jq, 7za, bat, nvim, python, node, go, etc.
  - [CLI for Useful Websites (e.g., github.com, cht.sh)](https://x-cmd.com/mod/cht): We have wrapped their APIs using shell and awk for daily use and to obtain corresponding services in scripts.
  - [AI Tools](https://x-cmd.com/mod/openai): We provide CLIs for ChatGPT, Gemini, Jina.ai, etc., and have wrapped corresponding shortcut commands for different application scenarios, such as `@gemini` for chatting with Gemini AI and `@zh` for using AI to translate specified content or command results.
