### PR TITLE
Add windows-to-wsl2-screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [usql](https://github.com/xo/usql) - Universal command-line interface for SQL databases.
 * [v](https://github.com/rupa/v) - z for vim.
 * [wemux](https://github.com/zolrath/wemux) - Multi-User Tmux Made Easy
+* [windows-to-wsl2-screenshots](https://github.com/jddev273/windows-to-wsl2-screenshots) - Auto-save Windows screenshots to WSL2 and paste paths directly into any app that uses WSL2.
 * [xiki](https://github.com/trogdoro/xiki) - Makes the shell console more friendly and powerful
 * [xplr](https://github.com/sayanarijit/xplr) -  A hackable, minimal, fast TUI file explorer
 * [xsv](https://github.com/BurntSushi/xsv) - a fast CSV command line toolkit written in Rust


### PR DESCRIPTION
Adding screenshot automation tool for WSL2 developers using tools like Claude Code. Streamlines workflow by auto-saving Windows screenshots to WSL2 and copying paths to clipboard