### PR TITLE
Add releaserun CLI to For Developers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [slap](https://github.com/slap-editor/slap) - Sublime-like terminal-based text editor that runs on Node.js
 * [shipit](https://github.com/sapegin/shipit) - Minimalistic SSH deployment
 * [starring](https://github.com/ritz078/starring) - Automatically star the npm-packages that you are using on GitHub.
+* [releaserun](https://github.com/Releaserun/releaserun-cli) - CLI to check your Node.js, Python, Go, Rust, and Docker stack for EOL dependencies, outdated versions, and security advisories. Run `releaserun check` to get a health grade for your project.
 * [tag](https://github.com/aykamko/tag) - Instantly jump to your ag matches.
 * [trunk](https://www.npmjs.com/package/@trunkio/launcher) - Blazingly fast meta code checker and formatter
 * [vmn](https://github.com/final-israel/vmn) - git-based automatic versioning and state recovery solution agnostic to language or architecture


### PR DESCRIPTION
## What this adds

**[releaserun](https://github.com/Releaserun/releaserun-cli)** — a developer CLI for checking your stack's health.

```
npm install -g releaserun
releaserun check
```

Checks Node.js, Python, Go, Rust, Docker, and PostgreSQL against end-of-life dates, outdated version data, and security advisories. Returns a health grade (A–F) per technology, with the specific version you're running vs. the current stable/LTS.

Added to **For Developers** section (command-line development, version control, and deployment).