### PR TITLE
Add ccline - type natural language at zsh prompt, get AI answer and run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [task-manager](https://github.com/lingtalfi/task-manager) - Execute all your scripts with just two or three keystrokes.
 * [td-cli](https://github.com/darrikonn/td-cli) - A todo command line manager to organize and manage your todos across multiple projects.
 * [tere](https://github.com/mgunyho/tere) - A faster alternative to cd + ls
+* [ccline](https://github.com/jianshuo/ccline) - Type a natural-language thought at your zsh prompt — no command, no prefix — get an AI answer (Claude/Codex) and run any suggested commands from an interactive menu.
 * [thefuck](https://github.com/nvbn/thefuck) - Fix common shell mistakes by using an easy to remember command
 * [tldr](https://github.com/raylee/tldr-sh-client) - A fully-functional bash client for tldr, simplified and community-driven man pages
 * [tmux](https://tmux.github.io/) - Amazing terminal multiplexer


### PR DESCRIPTION
## What does this add?

[ccline](https://github.com/jianshuo/ccline) — hijacks zsh's `command_not_found_handler` so you can type a natural-language thought directly at your prompt (no command, no prefix). It calls Claude or Codex, renders the answer as Markdown, and if the response contains shell commands, shows an interactive arrow-key menu to confirm and run them.

```
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
   find . -type f -size +100M
   ➤ Run all of them
   ✗ Cancel
```

- No extra dependencies: just zsh + `claude` or `codex` CLI
- One-word inputs (typos) pass through normally — no accidental API calls
- Selected commands run in the live shell (so `cd`, `export` etc. actually persist)

Added near `thefuck` under **Command-Line Productivity** as it solves the same "I don't know the exact command" problem with an AI-powered approach.