### PR TITLE
Add HimitsuShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [Fishtape](https://github.com/jorgebucaran/fishtape) - TAP producer and test harness for fish
 * [getoptions](https://github.com/ko1nksm/getoptions) - An elegant option parser for shell scripts (sh, bash and all POSIX shells)
 * [getopts.fish](https://github.com/jorgebucaran/getopts.fish) - CLI parser for fish
+* [HimitsuShell](https://himitsushell.com) - Compiles shell scripts into obfuscated binaries (alternative to shc)
 * [is.sh](https://github.com/qzb/is.sh) - An alternative for builtin test command, it will make your "if" statements pretty
 * [lumberjack](https://github.com/molovo/lumberjack) - A logging interface for shell scripts
 * [mo](https://github.com/tests-always-included/mo) - Mustache templates in pure bash


### PR DESCRIPTION
HimitsuShell is a tool that compiles shell scripts into obfuscated binaries. It uses an embedded shell interpreter, obfuscation, and anti-debugging protections, and can be used as an alternative to shc. The web edition is free with no account or usage limits.

Full docs: https://himitsushell.com

Disclosure: I'm the developer of HimitsuShell.