### PR TITLE
Add cmux-ssh-here

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A curated list of awesome command-line frameworks, toolkits, guides and gizmos. 
 * [browsh](https://github.com/browsh-org/browsh) - The modern text-based browser
 * [Buku](https://github.com/jarun/Buku) - Powerful command-line bookmark manager
 * [byobu](https://www.byobu.org) - Text-based window manager and terminal multiplexer
+* [cmux-ssh-here](https://github.com/viktor-silakov/cmux-ssh-here) - One-command ephemeral SSH server that shares a shell on this machine over the local network — no `sshd` config, keys, or passwords; the link self-expires.
 * [cod](https://github.com/dim-an/cod) — A completion daemon for shell that learns when you invoke `--help` commands
 * [CloudClip](https://github.com/skywind3000/CloudClip) - Your own clipboard in the cloud, copy and paste text with gist between different systems
 * [ddgr](https://github.com/jarun/ddgr) - DuckDuckGo from the terminal


### PR DESCRIPTION
Adds [cmux-ssh-here](https://github.com/viktor-silakov/cmux-ssh-here) under **Command-Line Productivity**. A one-command ephemeral SSH server that shares a shell on this machine over the local network — no `sshd` config, keys, or passwords; the link self-expires. MIT, actively maintained.